### PR TITLE
Fix breaking bug when extracting PHP

### DIFF
--- a/src/pot-extractor.js
+++ b/src/pot-extractor.js
@@ -484,9 +484,9 @@ export class PotExtractor {
         const visit = node => {
             if (node.kind === 'call') {
                 for (const {propName, position} of this.keywordDefs) {
-                    if (node.what.kind === 'identifier') {
+                    if (node.what.kind === 'classreference') {
                         if (node.what.name === propName) {
-                            const startOffset = src.substr(0, node.loc.start.offset).lastIndexOf(keyword)
+                            const startOffset = src.substr(0, node.loc.start.offset).lastIndexOf(propName)
                             try {
                                 const ids = this._evaluatePhpArgumentValues(node.arguments[position])
                                 for (const id of ids) {
@@ -532,7 +532,7 @@ export class PotExtractor {
 
         try {
             const ast = parser.parseCode(src)
-            const Node = parser.ast.constructor.prototype['node']
+            const Node = require("php-parser/src/ast/node")
             this.extractPhpNode(filename, src, Node, ast, startLine)
         } catch (err) {
             log.warn('extractPhpCode', `error parsing '${src.split(/\n/g)[err.loc.line - 1].trim()}' (${filename}:${err.loc.line})`)


### PR DESCRIPTION
I have been unable to run l10n-tools in a PHP repo for some weeks now.
With these changes, the tool now works perfectly on my tests, but please make sure to check if I did something wrong.


Line 487: I'm not sure what happened, but classreference seems to be the kind of all of my i18n functions
Line 489: I didn't find any reference to keyword elsewhere in this file, you probably forgot to change this when changing variable names
Line 535: The class Node doesn't seem to be listed on the ast constructor anymore, so I included it directly